### PR TITLE
Fixes cannot import name 'cached_download' from 'huggingface_hub' fro…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ wget
 seaborn
 piper_phonemize
 omegaconf
-huggingface_hub
+huggingface-hub==0.25.2
 # --------- vocos --------- #
 pyyaml
 encodec==0.1.1


### PR DESCRIPTION
Starting huggingface_hub 0.26 released last week when you try to install the project gives the error when you try to run it:

_ImportError: cannot import name 'cached_download' from 'huggingface_hub' (/home/jordi/sc/open-dubbing2/tmp/Matcha-TTS/python3-env/lib/python3.11/site-packages/huggingface_hub/__init__.py)_

I have not investigated this further, I have set the version of this library to the previous version that always have worked to allow me to continue using the repo.

Jordi,